### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ atari800 (4.2.0-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Name (from ./configure), Repository,
     Repository-Browse.
 
- -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 05:09:16 -0000
+ -- Antonin Kral <A.Kral@sh.cvut.cz>  Sat, 11 Sep 2021 05:09:16 -0000
 
 atari800 (4.2.0-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 atari800 (4.2.0-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
+  * Set upstream metadata fields: Name (from ./configure), Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 05:09:16 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+atari800 (4.2.0-2) UNRELEASED; urgency=medium
+
+  * Bump debhelper from old 12 to 13.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 05:09:16 -0000
+
 atari800 (4.2.0-1) unstable; urgency=medium
 
   * New upstream version 4.2.0

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: atari800
 Section: contrib/otherosfs
 Priority: optional
 Maintainer: Antonin Kral <A.Kral@sh.cvut.cz>
-Build-Depends: libsdl1.2-dev, zlib1g-dev, libreadline-dev, libgl1-mesa-dev, libpng-dev, imagemagick, dpkg-dev (>= 1.20), debhelper-compat (= 12)
+Build-Depends: libsdl1.2-dev, zlib1g-dev, libreadline-dev, libgl1-mesa-dev, libpng-dev, imagemagick, dpkg-dev (>= 1.20), debhelper-compat (= 13)
 Standards-Version: 4.5.1
 Vcs-Git: https://github.com/bobek/aranym800-debian.git
 Vcs-Browser: https://github.com/bobek/aranym800-debian

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,4 @@
 ---
 Name: Atari800
-Repository: https://github.com/Akheon23/atari800.git
-Repository-Browse: https://github.com/Akheon23/atari800
+Repository: https://github.com/atari800/atari800.git
+Repository-Browse: https://github.com/atari800/atari800

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Name: Atari800
+Repository: https://github.com/Akheon23/atari800.git
+Repository-Browse: https://github.com/Akheon23/atari800


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Name (from ./configure), Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/atari800/73a6a262-1b7b-401a-9065-bcb90edcd18e.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/73a6a262-1b7b-401a-9065-bcb90edcd18e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/73a6a262-1b7b-401a-9065-bcb90edcd18e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/73a6a262-1b7b-401a-9065-bcb90edcd18e/diffoscope)).
